### PR TITLE
HCK-8151: use primary or unique constraint for relationship parent field

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,14 @@
             "disableDenormalization": true,
             "enableComplexTypesNormalization": true,
             "relationships": {
-                "compositeRelationships": true
+                "compositeRelationships": {
+                    "allowRelationshipsByProperties": [
+                        "primaryKey",
+                        "unique",
+                        "compositeUniqueKey",
+                        "compositePrimaryKey"
+                    ]
+                }
             },
             "FEScriptCommentsSupported": true,
             "disableJsonDataMaxLength": true,


### PR DESCRIPTION
## Content

A relationship parent field should be:

a PK or
a part of composite PK or
UK or
a part of composite PK