### PR TITLE
HCK-12369 Configure new view name compatible with the target specs: "new_view"

### DIFF
--- a/properties_pane/defaultData.json
+++ b/properties_pane/defaultData.json
@@ -26,6 +26,7 @@
 	"relationship": {},
 	"user": {},
 	"view": {
+		"name": "new_view",
 		"viewOn": "",
 		"pipeline": ""
 	},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12369" title="HCK-12369" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12369</a>  [Teradata][RE] Tables and Views unexpectedly reversed into 2 different databases
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Bug https://hackolade.atlassian.net/browse/HCK-12369 has the initial root cause: the created views contain a space in their name, "new view," which leads to undesired behavior during reverse engineering. Since this situation is not ideal, let's improve the names of the new views (as we did for other targets) to eliminate spaces.

We won't improve the reverse-engineering to deal with spaces in names as it is not a realistic use case.