### PR TITLE
HCK-15100: add entity level to Teradata FE

### DIFF
--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -13,7 +13,10 @@
 	},
 	"feLevelSelector": {
 		"container": true,
-		"model": true
+		"model": true,
+		"entity": {
+			"separateBucket": true
+		}
 	},
 	"compMode": {
 		"entity": true,

--- a/localization/en.json
+++ b/localization/en.json
@@ -157,10 +157,10 @@
 	"MODAL_WINDOW___FE_SCRIPT_OPTION_CREATE": "Create",
 	"MODAL_WINDOW___FE_SCRIPT_OPTION_UPDATE": "Alter",
 	"FE_LEVEL_SELECTOR_TITLE": "Databases",
-	"FE_LEVEL_SELECTOR_CONTAINER": "Individual",
-	"FE_LEVEL_SELECTOR_MODEL": "Combined",
+	"FE_LEVEL_SELECTOR_CONTAINER": "Database",
+	"FE_LEVEL_SELECTOR_MODEL": "Model",
+	"FE_LEVEL_SELECTOR_ENTITY": "Table",
 	"MODAL_WINDOW___CONNECT_INVALID_CREDENTIALS_ERROR": "Unable to connect to Teradata instance due to one of the following reasons:\n<ul><li>The User ID, Password, or Account is incorrect.</li><li>The authentication method used is not supported (only basic authentication is allowed; LDAP and other methods are not supported).</li>\nPlease double-check your credentials and ensure you are using basic authentication. For more information, please refer to the <a href='https://hackolade.com/help/ConnecttoaTeradatainstance.html'>online documentation</a>.",
-
 	"MAIN_MENU___ATTRIBUTES": "Columns in Table Boxes",
 	"MAIN_MENU___DESCRIPTIONS": "Description in Table Boxes",
 	"MAIN_MENU___HIDE_ALL_ATTRIBUTES": "Empty Table Boxes",
@@ -175,7 +175,6 @@
 	"MODAL_WINDOW___OPTIONS_DISPLAY_ERD_V_FIELDS": "Columns",
 	"MODAL_WINDOW___OPTIONS_DISPLAY_REQUIRED_ATTRIBUTES": "Required columns",
 	"MODAL_WINDOW___OPTIONS_DISPLAY_NULLABLE_ATTRIBUTES": "Nullable columns",
-
 	"CUSTOM_SCRIPT_CONTAINER_VAR_NAME": "Database name",
 	"CUSTOM_SCRIPT_CONTAINER_VAR": "databaseName",
 	"CUSTOM_SCRIPT_ENTITY_VAR_NAME": "Table name",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-15100" title="HCK-15100" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-15100</a>  [Frostbank][Teradata] Allow FE DDL at entity level
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Technical details

- Added new "Table" level option in FE
- Change the name of other 2 opions: 
    -Individual -> Database
    -Combined -> Model