### PR TITLE
HCK-15943: remove wrong default value for "Order keys" property

### DIFF
--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -1122,7 +1122,6 @@ making sure that you maintain a proper JSON format.
 						"propertyKeyword": "orderKeys",
 						"propertyType": "fieldList",
 						"template": "orderedList",
-						"defaultValue": "",
 						"templateOptions": {
 							"maxFields": 1
 						},
@@ -1149,7 +1148,6 @@ making sure that you maintain a proper JSON format.
 						"propertyKeyword": "orderKeys",
 						"propertyType": "fieldList",
 						"template": "orderedList",
-						"defaultValue": "",
 						"dependency": {
 							"key": "orderBy",
 							"value": "HASH"


### PR DESCRIPTION
## Content

Remove the wrong default value (empty string) for the "Order keys" `fieldList` property.
This may cause issues, as the expected value for the `fieldList` properties is an array.